### PR TITLE
ApolloPagination: Support for `loadAllPages`

### DIFF
--- a/Tests/ApolloPaginationTests/AnyGraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/AnyGraphQLQueryPagerTests.swift
@@ -89,6 +89,19 @@ final class AnyGraphQLQueryPagerTests: XCTestCase {
     XCTAssertEqual(expectedViewModel, "Leia Organa")
   }
 
+  func test_loadAll() throws {
+    let pager = createPager()
+
+    let firstPageExpectation = Mocks.Hero.FriendsQuery.expectationForFirstPage(server: server)
+    let lastPageExpectation = Mocks.Hero.FriendsQuery.expectationForSecondPage(server: server)
+    let loadAllExpectation = expectation(description: "Load all pages")
+    pager.subscribe { _ in
+      loadAllExpectation.fulfill()
+    }
+    try pager.loadAll()
+    wait(for: [firstPageExpectation, lastPageExpectation, loadAllExpectation], timeout: 5)
+  }
+
   // MARK: - Test helpers
 
   private func createPager() -> GraphQLQueryPager<Query, Query> {

--- a/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
@@ -234,6 +234,19 @@ final class ForwardPaginationTests: XCTestCase, CacheDependentTesting {
     }
   }
 
+  func test_loadAll() async throws {
+    let pager = createPager()
+
+    let firstPageExpectation = Mocks.Hero.FriendsQuery.expectationForFirstPage(server: server)
+    let lastPageExpectation = Mocks.Hero.FriendsQuery.expectationForSecondPage(server: server)
+    let loadAllExpectation = expectation(description: "Load all pages")
+    await pager.subscribe(onUpdate: { _ in
+      loadAllExpectation.fulfill()
+    }).store(in: &cancellables)
+    try await pager.loadAll()
+    await fulfillment(of: [firstPageExpectation, lastPageExpectation, loadAllExpectation], timeout: 5)
+  }
+
   private func createPager() -> GraphQLQueryPager<Query, Query>.Actor {
     let initialQuery = Query()
     initialQuery.__variables = ["id": "2001", "first": 2, "after": GraphQLNullable<String>.null]

--- a/Tests/ApolloPaginationTests/FriendsQuery+TestHelpers.swift
+++ b/Tests/ApolloPaginationTests/FriendsQuery+TestHelpers.swift
@@ -1,10 +1,13 @@
+import ApolloAPI
 import ApolloInternalTestHelpers
 import XCTest
 
 extension Mocks.Hero.FriendsQuery {
   
   static func expectationForFirstPage(server: MockGraphQLServer) -> XCTestExpectation {
-    server.expect(MockQuery<Mocks.Hero.FriendsQuery>.self) { _ in
+    let query = MockQuery<Mocks.Hero.FriendsQuery>()
+    query.__variables = ["id": "2001", "first": 2, "after": GraphQLNullable<String>.null]
+    return server.expect(query) { _ in
       let pageInfo: [AnyHashable: AnyHashable] = [
         "__typename": "PageInfo",
         "endCursor": "Y3Vyc29yMg==",
@@ -47,7 +50,9 @@ extension Mocks.Hero.FriendsQuery {
   }
   
   static func expectationForSecondPage(server: MockGraphQLServer) -> XCTestExpectation {
-    server.expect(MockQuery<Mocks.Hero.FriendsQuery>.self) { _ in
+    let query = MockQuery<Mocks.Hero.FriendsQuery>()
+    query.__variables = ["id": "2001", "first": 2, "after": "Y3Vyc29yMg=="]
+    return server.expect(query) { _ in
       let pageInfo: [AnyHashable: AnyHashable] = [
         "__typename": "PageInfo",
         "endCursor": "Y3Vyc29yMw==",

--- a/apollo-ios-pagination/Sources/ApolloPagination/AnyGraphQLPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AnyGraphQLPager.swift
@@ -96,6 +96,10 @@ public class AnyGraphQLQueryPager<Model> {
   public func cancel() {
     pager.cancel()
   }
+
+  public func loadAll() throws {
+    try pager.loadAll()
+  }
 }
 
 extension GraphQLQueryPager.Actor {

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -238,7 +238,6 @@ extension GraphQLQueryPager {
     public func subscribe(onUpdate: @MainActor @escaping (Result<Output, Error>) -> Void) -> AnyCancellable {
       $currentValue.compactMap({ $0 }).sink { [weak self] result in
         guard let self else { return }
-        print(result)
         Task {
           let isLoadingAll = await self.isLoadingAll
           guard !isLoadingAll else { return }

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -271,6 +271,8 @@ extension GraphQLQueryPager {
       initialPageResult = nil
       activeTask?.cancel()
       activeTask = nil
+      initialFetchTask?.cancel()
+      initialFetchTask = nil
       subscribers.forEach { $0.cancel() }
       subscribers.removeAll()
     }


### PR DESCRIPTION
### What are you trying to accomplish?

I want consumers of the `GraphQLPager` to be able to load all pages at once, should they desire to do so. 

<!-- Please explain the why you made this change. What existing problem does the pull request solve? Links to related to issues, pull requests, discussions, documents or Slack threads are highly encouraged. -->

### What approach did you choose and why?

First, I modified the `fetch` function to follow `async`/`await` syntax. That's so that we can `await` its return prior to beginning to loop over `loadMore`. 

Then, I implemented the function using a while loop.

Finally, I made additive changes to the `MockGraphQLServer` to support subsequent loads of this nature. 

<!-- Describe your thought process in making these changes. List any tradeoffs you made to take on or pay down tech debt. Identify any work you did to mitigate risk. Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?

No?

<!-- Identify remaining risks and confess any uncertainties you may have about the correctness of the changes. Highlight anything on which you would like a second (or third) opinion. -->

### If something goes wrong, what are the mitigation strategies?

- **Rollback** - This change can only be disabled by reverting this pull request or commit.