### PR TITLE
[Apollo Pagination] Improve ReversePagination support, implement `loadAll` support, Bidirectional Pagination

### DIFF
--- a/Tests/ApolloPaginationTests/AnyGraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/AnyGraphQLQueryPagerTests.swift
@@ -89,6 +89,19 @@ final class AnyGraphQLQueryPagerTests: XCTestCase {
     XCTAssertEqual(expectedViewModel, "Leia Organa")
   }
 
+  func test_loadAll() throws {
+    let pager = createPager()
+
+    let firstPageExpectation = Mocks.Hero.FriendsQuery.expectationForFirstPage(server: server)
+    let lastPageExpectation = Mocks.Hero.FriendsQuery.expectationForSecondPage(server: server)
+    let loadAllExpectation = expectation(description: "Load all pages")
+    pager.subscribe { _ in
+      loadAllExpectation.fulfill()
+    }
+    try pager.loadAll()
+    wait(for: [firstPageExpectation, lastPageExpectation, loadAllExpectation], timeout: 5)
+  }
+
   // MARK: - Test helpers
 
   private func createPager() -> GraphQLQueryPager<Query, Query> {

--- a/Tests/ApolloPaginationTests/AnyGraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/AnyGraphQLQueryPagerTests.swift
@@ -55,7 +55,7 @@ final class AnyGraphQLQueryPagerTests: XCTestCase {
   }
 
   func test_passesBackSeparateData() throws {
-    let anyPager = createPager().eraseToAnyPager { initial, next in
+    let anyPager = createPager().eraseToAnyPager { _, initial, next in
       if let latestPage = next.last {
         return latestPage.hero.friendsConnection.friends.last?.name
       }

--- a/Tests/ApolloPaginationTests/AnyGraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/AnyGraphQLQueryPagerTests.swift
@@ -127,7 +127,8 @@ final class AnyGraphQLQueryPagerTests: XCTestCase {
           "after": pageInfo.endCursor,
         ]
         return nextQuery
-      }
+      },
+      previousPageResolver: nil
     )
   }
 

--- a/Tests/ApolloPaginationTests/BidirectionalPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/BidirectionalPaginationTests.swift
@@ -94,7 +94,6 @@ final class BidirectionalPaginationTests: XCTestCase, CacheDependentTesting {
     var nextCount = await pager.nextPageVarMap.values.count
     XCTAssertEqual(nextCount, 1)
 
-
     let previousPageExpectation = Mocks.Hero.BidirectionalFriendsQuery.expectationForPreviousPage(server: server)
     let previousPageFetch = expectation(description: "Previous Page")
     previousPageFetch.assertForOverFulfill = false
@@ -135,13 +134,13 @@ final class BidirectionalPaginationTests: XCTestCase, CacheDependentTesting {
     let previousPageExpectation = Mocks.Hero.BidirectionalFriendsQuery.expectationForPreviousPage(server: server)
     let lastPageExpectation = Mocks.Hero.BidirectionalFriendsQuery.expectationForLastPage(server: server)
 
-    //        let loadAllExpectation = expectation(description: "Load all pages")
+    let loadAllExpectation = expectation(description: "Load all pages")
     await pager.subscribe(onUpdate: { _ in
-      //            loadAllExpectation.fulfill()
+      loadAllExpectation.fulfill()
     }).store(in: &cancellables)
     try await pager.loadAll()
     await fulfillment(
-      of: [firstPageExpectation, lastPageExpectation, previousPageExpectation,],
+      of: [firstPageExpectation, lastPageExpectation, previousPageExpectation, loadAllExpectation],
       timeout: 5
     )
 
@@ -178,7 +177,7 @@ final class BidirectionalPaginationTests: XCTestCase, CacheDependentTesting {
           "id": "2001",
           "first": 1,
           "after": pageInfo.endCursor,
-          "before": GraphQLNullable<String>.null
+          "before": GraphQLNullable<String>.null,
         ]
         return nextQuery
       },
@@ -188,7 +187,7 @@ final class BidirectionalPaginationTests: XCTestCase, CacheDependentTesting {
           "id": "2001",
           "first": 1,
           "before": pageInfo.startCursor,
-          "after": GraphQLNullable<String>.null
+          "after": GraphQLNullable<String>.null,
         ]
         return previousQuery
       }

--- a/Tests/ApolloPaginationTests/BidirectionalPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/BidirectionalPaginationTests.swift
@@ -1,0 +1,197 @@
+import Apollo
+import ApolloAPI
+import ApolloInternalTestHelpers
+import Combine
+import XCTest
+
+@testable import ApolloPagination
+
+final class BidirectionalPaginationTests: XCTestCase, CacheDependentTesting {
+
+  private typealias Query = MockQuery<Mocks.Hero.BidirectionalFriendsQuery>
+
+  var cacheType: TestCacheProvider.Type {
+    InMemoryTestCacheProvider.self
+  }
+
+  var cache: NormalizedCache!
+  var server: MockGraphQLServer!
+  var client: ApolloClient!
+  var cancellables: [AnyCancellable] = []
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+
+    cache = try makeNormalizedCache()
+    let store = ApolloStore(cache: cache)
+
+    server = MockGraphQLServer()
+    let networkTransport = MockNetworkTransport(server: server, store: store)
+
+    client = ApolloClient(networkTransport: networkTransport, store: store)
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+  }
+
+  override func tearDownWithError() throws {
+    cache = nil
+    server = nil
+    client = nil
+    cancellables.forEach { $0.cancel() }
+    cancellables = []
+
+    try super.tearDownWithError()
+  }
+
+  func test_fetchMultiplePages() async throws {
+    let pager = createPager()
+    let serverExpectation = Mocks.Hero.BidirectionalFriendsQuery.expectationForFirstFetchInMiddleOfList(server: server)
+
+    var results: [Result<GraphQLQueryPager<Query, Query>.Output, Error>] = []
+    let firstPageExpectation = expectation(description: "First page")
+    var subscription = await pager.subscribe(onUpdate: { _ in
+      firstPageExpectation.fulfill()
+    })
+    await pager.fetch()
+    await fulfillment(of: [serverExpectation, firstPageExpectation], timeout: 1)
+    subscription.cancel()
+    var result = try await XCTUnwrapping(await pager.currentValue)
+    results.append(result)
+    XCTAssertSuccessResult(result) { output in
+      XCTAssertTrue(output.nextPages.isEmpty)
+      XCTAssertEqual(output.initialPage.hero.friendsConnection.friends.count, 1)
+      XCTAssertEqual(output.initialPage.hero.friendsConnection.totalCount, 3)
+      XCTAssertEqual(output.updateSource, .fetch)
+    }
+
+    let secondPageExpectation = Mocks.Hero.BidirectionalFriendsQuery.expectationForLastPage(server: server)
+    let secondPageFetch = expectation(description: "Second Page")
+    secondPageFetch.expectedFulfillmentCount = 2
+    subscription = await pager.subscribe(onUpdate: { _ in
+      secondPageFetch.fulfill()
+    })
+
+    try await pager.loadMore()
+    await fulfillment(of: [secondPageExpectation, secondPageFetch], timeout: 1)
+    subscription.cancel()
+
+    result = try await XCTUnwrapping(await pager.currentValue)
+    results.append(result)
+
+    try XCTAssertSuccessResult(result) { output in
+      // Assert first page is unchanged
+      XCTAssertEqual(try? results.first?.get().initialPage, try? results.last?.get().initialPage)
+
+      XCTAssertFalse(output.nextPages.isEmpty)
+      XCTAssertEqual(output.nextPages.count, 1)
+      XCTAssertTrue(output.previousPages.isEmpty)
+      XCTAssertEqual(output.previousPages.count, 0)
+      let page = try XCTUnwrap(output.nextPages.first)
+      XCTAssertEqual(page.hero.friendsConnection.friends.count, 1)
+      XCTAssertEqual(output.updateSource, .fetch)
+    }
+    var previousCount = await pager.previousPageVarMap.values.count
+    XCTAssertEqual(previousCount, 0)
+    var nextCount = await pager.nextPageVarMap.values.count
+    XCTAssertEqual(nextCount, 1)
+
+
+    let previousPageExpectation = Mocks.Hero.BidirectionalFriendsQuery.expectationForPreviousPage(server: server)
+    let previousPageFetch = expectation(description: "Previous Page")
+    previousPageFetch.assertForOverFulfill = false
+    previousPageFetch.expectedFulfillmentCount = 2
+    subscription = await pager.subscribe(onUpdate: { _ in
+      previousPageFetch.fulfill()
+    })
+
+    try await pager.loadPrevious()
+    await fulfillment(of: [previousPageExpectation, previousPageFetch], timeout: 1)
+    subscription.cancel()
+
+    result = try await XCTUnwrapping(await pager.currentValue)
+    results.append(result)
+
+    try XCTAssertSuccessResult(result) { output in
+      // Assert first page is unchanged
+      XCTAssertEqual(try? results.first?.get().initialPage, try? results.last?.get().initialPage)
+
+      XCTAssertFalse(output.nextPages.isEmpty)
+      XCTAssertEqual(output.nextPages.count, 1)
+      XCTAssertFalse(output.previousPages.isEmpty)
+      XCTAssertEqual(output.previousPages.count, 1)
+      let page = try XCTUnwrap(output.previousPages.first)
+      XCTAssertEqual(page.hero.friendsConnection.friends.count, 1)
+      XCTAssertEqual(output.updateSource, .fetch)
+    }
+    previousCount = await pager.previousPageVarMap.values.count
+    XCTAssertEqual(previousCount, 1)
+    nextCount = await pager.nextPageVarMap.values.count
+    XCTAssertEqual(nextCount, 1)
+  }
+
+  func test_loadAll() async throws {
+    let pager = createPager()
+
+    let firstPageExpectation = Mocks.Hero.BidirectionalFriendsQuery.expectationForFirstFetchInMiddleOfList(server: server)
+    let previousPageExpectation = Mocks.Hero.BidirectionalFriendsQuery.expectationForPreviousPage(server: server)
+    let lastPageExpectation = Mocks.Hero.BidirectionalFriendsQuery.expectationForLastPage(server: server)
+
+    //        let loadAllExpectation = expectation(description: "Load all pages")
+    await pager.subscribe(onUpdate: { _ in
+      //            loadAllExpectation.fulfill()
+    }).store(in: &cancellables)
+    try await pager.loadAll()
+    await fulfillment(
+      of: [firstPageExpectation, lastPageExpectation, previousPageExpectation,],
+      timeout: 5
+    )
+
+    let result = try await XCTUnwrapping(try await pager.currentValue?.get())
+    XCTAssertFalse(result.previousPages.isEmpty)
+    XCTAssertEqual(result.initialPage.hero.friendsConnection.friends.count, 1)
+    XCTAssertFalse(result.nextPages.isEmpty)
+
+    let friends = (result.previousPages.first?.hero.friendsConnection.friends ?? []) + result.initialPage.hero.friendsConnection.friends + (result.nextPages.first?.hero.friendsConnection.friends ?? [])
+
+    XCTAssertEqual(Set(friends).count, 3)
+  }
+
+  private func createPager() -> GraphQLQueryPager<Query, Query>.Actor {
+    let initialQuery = Query()
+    initialQuery.__variables = ["id": "2001", "first": 1, "after": "Y3Vyc29yMw==", "before": GraphQLNullable<String>.null]
+    return GraphQLQueryPager<Query, Query>.Actor(
+      client: client,
+      initialQuery: initialQuery,
+      extractPageInfo: { data in
+        switch data {
+        case .initial(let data), .paginated(let data):
+          return CursorBasedPagination.BidirectionalPagination(
+            hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
+            endCursor: data.hero.friendsConnection.pageInfo.endCursor,
+            hasPrevious: data.hero.friendsConnection.pageInfo.hasPreviousPage,
+            startCursor: data.hero.friendsConnection.pageInfo.startCursor
+          )
+        }
+      },
+      nextPageResolver: { pageInfo in
+        let nextQuery = Query()
+        nextQuery.__variables = [
+          "id": "2001",
+          "first": 1,
+          "after": pageInfo.endCursor,
+          "before": GraphQLNullable<String>.null
+        ]
+        return nextQuery
+      },
+      previousPageResolver: { pageInfo in
+        let previousQuery = Query()
+        previousQuery.__variables = [
+          "id": "2001",
+          "first": 1,
+          "before": pageInfo.startCursor,
+          "after": GraphQLNullable<String>.null
+        ]
+        return previousQuery
+      }
+    )
+  }
+}

--- a/Tests/ApolloPaginationTests/ConcurrencyTest.swift
+++ b/Tests/ApolloPaginationTests/ConcurrencyTest.swift
@@ -138,7 +138,8 @@ final class ConcurrencyTests: XCTestCase {
           "after": pageInfo.endCursor,
         ]
         return nextQuery
-      }
+      },
+      previousPageResolver: nil
     )
   }
 
@@ -165,7 +166,8 @@ final class ConcurrencyTests: XCTestCase {
           "after": pageInfo.endCursor,
         ]
         return nextQuery
-      }
+      },
+      previousPageResolver: nil
     )
   }
 

--- a/Tests/ApolloPaginationTests/ConcurrencyTest.swift
+++ b/Tests/ApolloPaginationTests/ConcurrencyTest.swift
@@ -25,7 +25,7 @@ final class ConcurrencyTests: XCTestCase {
 
   func test_concurrentFetches() async throws {
     let pager = createPager()
-    var results: [Result<(Query.Data, [Query.Data], UpdateSource), Error>] = []
+    var results: [Result<GraphQLQueryPager<Query, Query>.Output, Error>] = []
     let resultsExpectation = expectation(description: "Results arrival")
     resultsExpectation.expectedFulfillmentCount = 2
     await pager.subscribe { result in
@@ -48,7 +48,7 @@ final class ConcurrencyTests: XCTestCase {
 
   func test_concurrentFetches_nonisolated() throws {
     let pager = createNonisolatedPager()
-    var results: [Result<(Query.Data, [Query.Data], UpdateSource), Error>] = []
+    var results: [Result<GraphQLQueryPager<Query, Query>.Output, Error>] = []
     let initialExpectation = expectation(description: "Initial")
     initialExpectation.assertForOverFulfill = false
     let nextExpectation = expectation(description: "Next")

--- a/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
@@ -270,7 +270,8 @@ final class ForwardPaginationTests: XCTestCase, CacheDependentTesting {
           "after": pageInfo.endCursor,
         ]
         return nextQuery
-      }
+      },
+      previousPageResolver: nil
     )
   }
 }

--- a/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ForwardPaginationTests.swift
@@ -234,6 +234,19 @@ final class ForwardPaginationTests: XCTestCase, CacheDependentTesting {
     }
   }
 
+  func test_loadAll() async throws {
+    let pager = createPager()
+
+    let firstPageExpectation = Mocks.Hero.FriendsQuery.expectationForFirstPage(server: server)
+    let lastPageExpectation = Mocks.Hero.FriendsQuery.expectationForSecondPage(server: server)
+    let loadAllExpectation = expectation(description: "Load all pages")
+    await pager.subscribe(onUpdate: { _ in
+      loadAllExpectation.fulfill()
+    }).store(in: &cancellables)
+    try await pager.loadAll()
+    await fulfillment(of: [firstPageExpectation, lastPageExpectation, loadAllExpectation], timeout: 5)
+  }
+
   private func createPager() -> GraphQLQueryPager<Query, Query>.Actor {
     let initialQuery = Query()
     initialQuery.__variables = ["id": "2001", "first": 2, "after": GraphQLNullable<String>.null]

--- a/Tests/ApolloPaginationTests/FriendsQuery+TestHelpers.swift
+++ b/Tests/ApolloPaginationTests/FriendsQuery+TestHelpers.swift
@@ -89,3 +89,89 @@ extension Mocks.Hero.FriendsQuery {
     }
   }
 }
+
+extension Mocks.Hero.ReverseFriendsQuery {
+  static func expectationForPreviousItem(server: MockGraphQLServer) -> XCTestExpectation {
+    let query = MockQuery<Mocks.Hero.ReverseFriendsQuery>()
+    query.__variables = ["id": "2001", "first": 2, "before": "Y3Vyc29yMg=="]
+    return server.expect(query) { _ in
+      let pageInfo: [AnyHashable: AnyHashable] = [
+        "__typename": "PageInfo",
+        "startCursor": "Y3Vyc29yZg==",
+        "hasPreviousPage": false,
+      ]
+      let friends: [[String: AnyHashable]] = [
+        [
+          "__typename": "Human",
+          "name": "Luke Skywalker",
+          "id": "1000",
+        ],
+      ]
+      let friendsConnection: [String: AnyHashable] = [
+        "__typename": "FriendsConnection",
+        "totalCount": 3,
+        "friends": friends,
+        "pageInfo": pageInfo,
+      ]
+
+      let hero: [String: AnyHashable] = [
+        "__typename": "Droid",
+        "id": "2001",
+        "name": "R2-D2",
+        "friendsConnection": friendsConnection,
+      ]
+
+      let data: [String: AnyHashable] = [
+        "hero": hero
+      ]
+
+      return [
+        "data": data
+      ]
+    }
+  }
+  static func expectationForLastItem(server: MockGraphQLServer) -> XCTestExpectation {
+    let query = MockQuery<Mocks.Hero.ReverseFriendsQuery>()
+    query.__variables = ["id": "2001", "first": 2, "before": "Y3Vyc29yMw=="]
+    return server.expect(query) { _ in
+      let pageInfo: [AnyHashable: AnyHashable] = [
+        "__typename": "PageInfo",
+        "startCursor": "Y3Vyc29yMg==",
+        "hasPreviousPage": true,
+      ]
+      let friends: [[String: AnyHashable]] = [
+        [
+          "__typename": "Human",
+          "name": "Han Solo",
+          "id": "1002",
+        ],
+        [
+          "__typename": "Human",
+          "name": "Leia Organa",
+          "id": "1003",
+        ],
+      ]
+      let friendsConnection: [String: AnyHashable] = [
+        "__typename": "FriendsConnection",
+        "totalCount": 3,
+        "friends": friends,
+        "pageInfo": pageInfo,
+      ]
+
+      let hero: [String: AnyHashable] = [
+        "__typename": "Droid",
+        "id": "2001",
+        "name": "R2-D2",
+        "friendsConnection": friendsConnection,
+      ]
+
+      let data: [String: AnyHashable] = [
+        "hero": hero
+      ]
+
+      return [
+        "data": data
+      ]
+    }
+  }
+}

--- a/Tests/ApolloPaginationTests/FriendsQuery+TestHelpers.swift
+++ b/Tests/ApolloPaginationTests/FriendsQuery+TestHelpers.swift
@@ -3,7 +3,6 @@ import ApolloInternalTestHelpers
 import XCTest
 
 extension Mocks.Hero.FriendsQuery {
-  
   static func expectationForFirstPage(server: MockGraphQLServer) -> XCTestExpectation {
     let query = MockQuery<Mocks.Hero.FriendsQuery>()
     query.__variables = ["id": "2001", "first": 2, "after": GraphQLNullable<String>.null]
@@ -31,24 +30,24 @@ extension Mocks.Hero.FriendsQuery {
         "friends": friends,
         "pageInfo": pageInfo,
       ]
-      
+
       let hero: [String: AnyHashable] = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
         "friendsConnection": friendsConnection,
       ]
-      
+
       let data: [String: AnyHashable] = [
         "hero": hero
       ]
-      
+
       return [
         "data": data
       ]
     }
   }
-  
+
   static func expectationForSecondPage(server: MockGraphQLServer) -> XCTestExpectation {
     let query = MockQuery<Mocks.Hero.FriendsQuery>()
     query.__variables = ["id": "2001", "first": 2, "after": "Y3Vyc29yMg=="]
@@ -71,18 +70,18 @@ extension Mocks.Hero.FriendsQuery {
         "friends": friends,
         "pageInfo": pageInfo,
       ]
-      
+
       let hero: [String: AnyHashable] = [
         "__typename": "Droid",
         "id": "2001",
         "name": "R2-D2",
         "friendsConnection": friendsConnection,
       ]
-      
+
       let data: [String: AnyHashable] = [
         "hero": hero
       ]
-      
+
       return [
         "data": data
       ]
@@ -149,6 +148,134 @@ extension Mocks.Hero.ReverseFriendsQuery {
           "__typename": "Human",
           "name": "Leia Organa",
           "id": "1003",
+        ],
+      ]
+      let friendsConnection: [String: AnyHashable] = [
+        "__typename": "FriendsConnection",
+        "totalCount": 3,
+        "friends": friends,
+        "pageInfo": pageInfo,
+      ]
+
+      let hero: [String: AnyHashable] = [
+        "__typename": "Droid",
+        "id": "2001",
+        "name": "R2-D2",
+        "friendsConnection": friendsConnection,
+      ]
+
+      let data: [String: AnyHashable] = [
+        "hero": hero
+      ]
+
+      return [
+        "data": data
+      ]
+    }
+  }
+}
+
+extension Mocks.Hero.BidirectionalFriendsQuery {
+  static func expectationForFirstFetchInMiddleOfList(server: MockGraphQLServer) -> XCTestExpectation {
+    let query = MockQuery<Mocks.Hero.BidirectionalFriendsQuery>()
+    query.__variables = ["id": "2001", "first": 1, "before": GraphQLNullable<String>.null, "after": "Y3Vyc29yMw=="]
+    return server.expect(query) { _ in
+      let pageInfo: [AnyHashable: AnyHashable] = [
+        "__typename": "PageInfo",
+        "startCursor": "Y3Vyc29yMw==",
+        "hasPreviousPage": true,
+        "endCursor": "Y3Vyc29yMg==",
+        "hasNextPage": true,
+      ]
+      let friends: [[String: AnyHashable]] = [
+        [
+          "__typename": "Human",
+          "name": "Leia Organa",
+          "id": "1003",
+        ],
+      ]
+      let friendsConnection: [String: AnyHashable] = [
+        "__typename": "FriendsConnection",
+        "totalCount": 3,
+        "friends": friends,
+        "pageInfo": pageInfo,
+      ]
+
+      let hero: [String: AnyHashable] = [
+        "__typename": "Droid",
+        "id": "2001",
+        "name": "R2-D2",
+        "friendsConnection": friendsConnection,
+      ]
+
+      let data: [String: AnyHashable] = [
+        "hero": hero
+      ]
+
+      return [
+        "data": data
+      ]
+    }
+  }
+
+  static func expectationForLastPage(server: MockGraphQLServer) -> XCTestExpectation {
+    let query = MockQuery<Mocks.Hero.BidirectionalFriendsQuery>()
+    query.__variables = ["id": "2001", "first": 1, "after": "Y3Vyc29yMg==", "before": GraphQLNullable<String>.null]
+    return server.expect(query) { _ in
+      let pageInfo: [AnyHashable: AnyHashable] = [
+        "__typename": "PageInfo",
+        "startCursor": "Y3Vyc29yMg==",
+        "hasPreviousPage": true,
+        "endCursor": "Y3Vyc29yMa==",
+        "hasNextPage": false,
+      ]
+      let friends: [[String: AnyHashable]] = [
+        [
+          "__typename": "Human",
+          "name": "Han Solo",
+          "id": "1002",
+        ],
+      ]
+      let friendsConnection: [String: AnyHashable] = [
+        "__typename": "FriendsConnection",
+        "totalCount": 3,
+        "friends": friends,
+        "pageInfo": pageInfo,
+      ]
+
+      let hero: [String: AnyHashable] = [
+        "__typename": "Droid",
+        "id": "2001",
+        "name": "R2-D2",
+        "friendsConnection": friendsConnection,
+      ]
+
+      let data: [String: AnyHashable] = [
+        "hero": hero
+      ]
+
+      return [
+        "data": data
+      ]
+    }
+  }
+
+  static func expectationForPreviousPage(server: MockGraphQLServer) -> XCTestExpectation {
+    let query = MockQuery<Mocks.Hero.BidirectionalFriendsQuery>()
+    query.__variables = ["id": "2001", "first": 1, "before": "Y3Vyc29yMw==", "after": GraphQLNullable<String>.null]
+    return server.expect(query) { _ in
+      let pageInfo: [AnyHashable: AnyHashable] = [
+        "__typename": "PageInfo",
+        "startCursor": "Y3Vyc29yMq==",
+        "hasPreviousPage": false,
+        "endCursor": "Y3Vyc29yMw==",
+        "hasNextPage": true,
+      ]
+      let friends: [[String: AnyHashable]] = [
+        [
+          "__typename": "Human",
+          "name": "Luke Skywalker",
+          "id": "1000",
         ],
       ]
       let friendsConnection: [String: AnyHashable] = [

--- a/Tests/ApolloPaginationTests/FriendsQuery+TestHelpers.swift
+++ b/Tests/ApolloPaginationTests/FriendsQuery+TestHelpers.swift
@@ -1,10 +1,13 @@
+import ApolloAPI
 import ApolloInternalTestHelpers
 import XCTest
 
 extension Mocks.Hero.FriendsQuery {
   
   static func expectationForFirstPage(server: MockGraphQLServer) -> XCTestExpectation {
-    server.expect(MockQuery<Mocks.Hero.FriendsQuery>.self) { _ in
+    let query = MockQuery<Mocks.Hero.FriendsQuery>()
+    query.__variables = ["id": "2001", "first": 2, "after": GraphQLNullable<String>.null]
+    return server.expect(query) { _ in
       let pageInfo: [AnyHashable: AnyHashable] = [
         "__typename": "PageInfo",
         "endCursor": "Y3Vyc29yMg==",
@@ -47,7 +50,9 @@ extension Mocks.Hero.FriendsQuery {
   }
   
   static func expectationForSecondPage(server: MockGraphQLServer) -> XCTestExpectation {
-    server.expect(MockQuery<Mocks.Hero.FriendsQuery>.self) { _ in
+    let query = MockQuery<Mocks.Hero.FriendsQuery>()
+    query.__variables = ["id": "2001", "first": 2, "after": "Y3Vyc29yMg=="]
+    return server.expect(query) { _ in
       let pageInfo: [AnyHashable: AnyHashable] = [
         "__typename": "PageInfo",
         "endCursor": "Y3Vyc29yMw==",

--- a/Tests/ApolloPaginationTests/GraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/GraphQLQueryPagerTests.swift
@@ -1,0 +1,149 @@
+import Apollo
+import ApolloAPI
+import ApolloInternalTestHelpers
+import Combine
+import XCTest
+
+@testable import ApolloPagination
+
+final class GraphQLQueryPagerTests: XCTestCase, CacheDependentTesting {
+    private typealias ReverseQuery = MockQuery<Mocks.Hero.ReverseFriendsQuery>
+    private typealias ForwardQuery = MockQuery<Mocks.Hero.FriendsQuery>
+
+
+    var cacheType: TestCacheProvider.Type {
+        InMemoryTestCacheProvider.self
+    }
+
+    var cache: NormalizedCache!
+    var server: MockGraphQLServer!
+    var client: ApolloClient!
+    var cancellables: [AnyCancellable] = []
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        cache = try makeNormalizedCache()
+        let store = ApolloStore(cache: cache)
+
+        server = MockGraphQLServer()
+        let networkTransport = MockNetworkTransport(server: server, store: store)
+
+        client = ApolloClient(networkTransport: networkTransport, store: store)
+        MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+    }
+
+    override func tearDownWithError() throws {
+        cache = nil
+        server = nil
+        client = nil
+        cancellables.forEach { $0.cancel() }
+        cancellables = []
+
+        try super.tearDownWithError()
+    }
+
+    func test_canLoadMore() async throws {
+        let pager = createForwardPager()
+
+        let serverExpectation = Mocks.Hero.FriendsQuery.expectationForFirstPage(server: server)
+
+        await pager.fetch()
+        await fulfillment(of: [serverExpectation])
+
+        var canLoadMore = await pager.canLoadNext
+        XCTAssertTrue(canLoadMore)
+
+        let secondPageExpectation = Mocks.Hero.FriendsQuery.expectationForSecondPage(server: server)
+        let secondPageFetch = expectation(description: "Second Page")
+        secondPageFetch.expectedFulfillmentCount = 2
+        let subscription = await pager.subscribe(onUpdate: { _ in
+            secondPageFetch.fulfill()
+        })
+        try await pager.loadMore()
+        await fulfillment(of: [secondPageExpectation, secondPageFetch])
+        subscription.cancel()
+        canLoadMore = await pager.canLoadNext
+        XCTAssertFalse(canLoadMore)
+    }
+
+    func test_canLoadPrevious() async throws {
+        let pager = createReversePager()
+
+        let serverExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForLastItem(server: server)
+
+        await pager.fetch()
+        await fulfillment(of: [serverExpectation])
+
+        var canLoadMore = await pager.canLoadPrevious
+        XCTAssertTrue(canLoadMore)
+
+        let secondPageExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForPreviousItem(server: server)
+        let secondPageFetch = expectation(description: "Second Page")
+        secondPageFetch.expectedFulfillmentCount = 2
+        let subscription = await pager.subscribe(onUpdate: { _ in
+            secondPageFetch.fulfill()
+        })
+        try await pager.loadPrevious()
+        await fulfillment(of: [secondPageExpectation, secondPageFetch])
+        subscription.cancel()
+        canLoadMore = await pager.canLoadPrevious
+        XCTAssertFalse(canLoadMore)
+    }
+
+    private func createReversePager() -> GraphQLQueryPager<ReverseQuery, ReverseQuery>.Actor {
+        let initialQuery = ReverseQuery()
+        initialQuery.__variables = ["id": "2001", "first": 2, "before": "Y3Vyc29yMw=="]
+        return GraphQLQueryPager<ReverseQuery, ReverseQuery>.Actor(
+            client: client,
+            initialQuery: initialQuery,
+            extractPageInfo: { data in
+                switch data {
+                case .initial(let data), .paginated(let data):
+                    return CursorBasedPagination.ReversePagination(
+                        hasPrevious: data.hero.friendsConnection.pageInfo.hasPreviousPage,
+                        startCursor: data.hero.friendsConnection.pageInfo.startCursor
+                    )
+                }
+            },
+            nextPageResolver: nil,
+            previousPageResolver: { pageInfo in
+                let nextQuery = ReverseQuery()
+                nextQuery.__variables = [
+                    "id": "2001",
+                    "first": 2,
+                    "before": pageInfo.startCursor,
+                ]
+                return nextQuery
+            }
+        )
+    }
+
+    private func createForwardPager() -> GraphQLQueryPager<ForwardQuery, ForwardQuery>.Actor {
+        let initialQuery = ForwardQuery()
+        initialQuery.__variables = ["id": "2001", "first": 2, "after": GraphQLNullable<String>.null]
+        return GraphQLQueryPager<ForwardQuery, ForwardQuery>.Actor(
+            client: client,
+            initialQuery: initialQuery,
+            extractPageInfo: { data in
+                switch data {
+                case .initial(let data), .paginated(let data):
+                    return CursorBasedPagination.ForwardPagination(
+                        hasNext: data.hero.friendsConnection.pageInfo.hasNextPage,
+                        endCursor: data.hero.friendsConnection.pageInfo.endCursor
+                    )
+                }
+            },
+            nextPageResolver: { pageInfo in
+                let nextQuery = ForwardQuery()
+                nextQuery.__variables = [
+                    "id": "2001",
+                    "first": 2,
+                    "after": pageInfo.endCursor,
+                ]
+                return nextQuery
+            },
+            previousPageResolver: nil
+        )
+    }
+}

--- a/Tests/ApolloPaginationTests/GraphQLQueryPagerTests.swift
+++ b/Tests/ApolloPaginationTests/GraphQLQueryPagerTests.swift
@@ -10,7 +10,6 @@ final class GraphQLQueryPagerTests: XCTestCase, CacheDependentTesting {
     private typealias ReverseQuery = MockQuery<Mocks.Hero.ReverseFriendsQuery>
     private typealias ForwardQuery = MockQuery<Mocks.Hero.FriendsQuery>
 
-
     var cacheType: TestCacheProvider.Type {
         InMemoryTestCacheProvider.self
     }

--- a/Tests/ApolloPaginationTests/Mocks.swift
+++ b/Tests/ApolloPaginationTests/Mocks.swift
@@ -5,6 +5,65 @@ import XCTest
 
 enum Mocks {
   enum Hero {
+    class ReverseFriendsQuery: MockSelectionSet {
+      override class var __selections: [Selection] { [
+        .field("hero", Hero?.self, arguments: ["id": .variable("id")])
+      ]}
+
+      var hero: Hero { __data["hero"] }
+
+      class Hero: MockSelectionSet {
+        override class var __selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("id", String.self),
+          .field("name", String.self),
+          .field("friendsConnection", FriendsConnection.self, arguments: [
+            "first": .variable("first"),
+            "before": .variable("before"),
+          ]),
+        ]}
+
+        var name: String { __data["name"] }
+        var id: String { __data["id"] }
+        var friendsConnection: FriendsConnection { __data["friendsConnection"] }
+
+        class FriendsConnection: MockSelectionSet {
+          override class var __selections: [Selection] {[
+            .field("__typename", String.self),
+            .field("totalCount", Int.self),
+            .field("friends", [Character].self),
+            .field("pageInfo", PageInfo.self),
+          ]}
+
+          var totalCount: Int { __data["totalCount"] }
+          var friends: [Character] { __data["friends"] }
+          var pageInfo: PageInfo { __data["pageInfo"] }
+
+          class Character: MockSelectionSet {
+            override class var __selections: [Selection] {[
+              .field("__typename", String.self),
+              .field("name", String.self),
+              .field("id", String.self),
+            ]}
+
+            var name: String { __data["name"] }
+            var id: String { __data["id"] }
+          }
+
+          class PageInfo: MockSelectionSet {
+            override class var __selections: [Selection] {[
+              .field("__typename", String.self),
+              .field("startCursor", Optional<String>.self),
+              .field("hasPreviousPage", Bool.self),
+            ]}
+
+            var startCursor: String? { __data["startCursor"] }
+            var hasPreviousPage: Bool { __data["hasPreviousPage"] }
+          }
+        }
+      }
+    }
+
     class FriendsQuery: MockSelectionSet {
       override class var __selections: [Selection] { [
         .field("hero", Hero?.self, arguments: ["id": .variable("id")])

--- a/Tests/ApolloPaginationTests/Mocks.swift
+++ b/Tests/ApolloPaginationTests/Mocks.swift
@@ -5,6 +5,69 @@ import XCTest
 
 enum Mocks {
   enum Hero {
+    class BidirectionalFriendsQuery: MockSelectionSet {
+      override class var __selections: [Selection] { [
+        .field("hero", Hero?.self, arguments: ["id": .variable("id")])
+      ]}
+
+      var hero: Hero { __data["hero"] }
+
+      class Hero: MockSelectionSet {
+        override class var __selections: [Selection] {[
+          .field("__typename", String.self),
+          .field("id", String.self),
+          .field("name", String.self),
+          .field("friendsConnection", FriendsConnection.self, arguments: [
+            "first": .variable("first"),
+            "before": .variable("before"),
+            "after": .variable("after"),
+          ]),
+        ]}
+
+        var name: String { __data["name"] }
+        var id: String { __data["id"] }
+        var friendsConnection: FriendsConnection { __data["friendsConnection"] }
+
+        class FriendsConnection: MockSelectionSet {
+          override class var __selections: [Selection] {[
+            .field("__typename", String.self),
+            .field("totalCount", Int.self),
+            .field("friends", [Character].self),
+            .field("pageInfo", PageInfo.self),
+          ]}
+
+          var totalCount: Int { __data["totalCount"] }
+          var friends: [Character] { __data["friends"] }
+          var pageInfo: PageInfo { __data["pageInfo"] }
+
+          class Character: MockSelectionSet {
+            override class var __selections: [Selection] {[
+              .field("__typename", String.self),
+              .field("name", String.self),
+              .field("id", String.self),
+            ]}
+
+            var name: String { __data["name"] }
+            var id: String { __data["id"] }
+          }
+
+          class PageInfo: MockSelectionSet {
+            override class var __selections: [Selection] {[
+              .field("__typename", String.self),
+              .field("startCursor", Optional<String>.self),
+              .field("hasPreviousPage", Bool.self),
+              .field("endCursor", Optional<String>.self),
+              .field("hasNextPage", Bool.self),
+            ]}
+
+            var endCursor: String? { __data["endCursor"] }
+            var hasNextPage: Bool { __data["hasNextPage"] }
+            var startCursor: String? { __data["startCursor"] }
+            var hasPreviousPage: Bool { __data["hasPreviousPage"] }
+          }
+        }
+      }
+    }
     class ReverseFriendsQuery: MockSelectionSet {
       override class var __selections: [Selection] { [
         .field("hero", Hero?.self, arguments: ["id": .variable("id")])
@@ -63,7 +126,6 @@ enum Mocks {
         }
       }
     }
-
     class FriendsQuery: MockSelectionSet {
       override class var __selections: [Selection] { [
         .field("hero", Hero?.self, arguments: ["id": .variable("id")])

--- a/Tests/ApolloPaginationTests/ReversePaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ReversePaginationTests.swift
@@ -7,47 +7,47 @@ import XCTest
 @testable import ApolloPagination
 
 final class ReversePaginationTests: XCTestCase, CacheDependentTesting {
-
+  
   private typealias Query = MockQuery<Mocks.Hero.ReverseFriendsQuery>
-
+  
   var cacheType: TestCacheProvider.Type {
     InMemoryTestCacheProvider.self
   }
-
+  
   var cache: NormalizedCache!
   var server: MockGraphQLServer!
   var client: ApolloClient!
   var cancellables: [AnyCancellable] = []
-
+  
   override func setUpWithError() throws {
     try super.setUpWithError()
-
+    
     cache = try makeNormalizedCache()
     let store = ApolloStore(cache: cache)
-
+    
     server = MockGraphQLServer()
     let networkTransport = MockNetworkTransport(server: server, store: store)
-
+    
     client = ApolloClient(networkTransport: networkTransport, store: store)
     MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
   }
-
+  
   override func tearDownWithError() throws {
     cache = nil
     server = nil
     client = nil
     cancellables.forEach { $0.cancel() }
     cancellables = []
-
+    
     try super.tearDownWithError()
   }
-
+  
   func test_fetchMultiplePages() async throws {
     let pager = createPager()
-
+    
     let serverExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForLastItem(server: server)
-
-    var results: [Result<(Query.Data, [Query.Data], UpdateSource), Error>] = []
+    
+    var results: [Result<GraphQLQueryPager<Query, Query>.Output, Error>] = []
     let firstPageExpectation = expectation(description: "First page")
     var subscription = await pager.subscribe(onUpdate: { _ in
       firstPageExpectation.fulfill()
@@ -57,46 +57,48 @@ final class ReversePaginationTests: XCTestCase, CacheDependentTesting {
     subscription.cancel()
     var result = try await XCTUnwrapping(await pager.currentValue)
     results.append(result)
-    XCTAssertSuccessResult(result) { value in
-      let (first, next, source) = value
-      XCTAssertTrue(next.isEmpty)
-      XCTAssertEqual(first.hero.friendsConnection.friends.count, 2)
-      XCTAssertEqual(first.hero.friendsConnection.totalCount, 3)
-      XCTAssertEqual(source, .fetch)
+    XCTAssertSuccessResult(result) { output in
+      XCTAssertTrue(output.nextPages.isEmpty)
+      XCTAssertEqual(output.initialPage.hero.friendsConnection.friends.count, 2)
+      XCTAssertEqual(output.initialPage.hero.friendsConnection.totalCount, 3)
+      XCTAssertEqual(output.updateSource, .fetch)
     }
-
+    
     let secondPageExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForPreviousItem(server: server)
     let secondPageFetch = expectation(description: "Second Page")
     secondPageFetch.expectedFulfillmentCount = 2
     subscription = await pager.subscribe(onUpdate: { _ in
       secondPageFetch.fulfill()
     })
-
+    
     try await pager.loadPrevious()
     await fulfillment(of: [secondPageExpectation, secondPageFetch], timeout: 1)
     subscription.cancel()
-
+    
     result = try await XCTUnwrapping(await pager.currentValue)
     results.append(result)
-
-    try XCTAssertSuccessResult(result) { value in
-      let (_, next, source) = value
+    
+    try XCTAssertSuccessResult(result) { output in
       // Assert first page is unchanged
-      XCTAssertEqual(try? results.first?.get().0, try? results.last?.get().0)
-
-      XCTAssertFalse(next.isEmpty)
-      XCTAssertEqual(next.count, 1)
-      let page = try XCTUnwrap(next.first)
+      XCTAssertEqual(try? results.first?.get().initialPage, try? results.last?.get().initialPage)
+      
+      XCTAssertFalse(output.previousPages.isEmpty)
+      XCTAssertEqual(output.previousPages.count, 1)
+      XCTAssertTrue(output.nextPages.isEmpty)
+      XCTAssertEqual(output.nextPages.count, 0)
+      let page = try XCTUnwrap(output.previousPages.first)
       XCTAssertEqual(page.hero.friendsConnection.friends.count, 1)
-      XCTAssertEqual(source, .fetch)
+      XCTAssertEqual(output.updateSource, .fetch)
     }
-    let count = await pager.varMap.values.count
-    XCTAssertEqual(count, 1)
+    let previousCount = await pager.previousPageVarMap.values.count
+    XCTAssertEqual(previousCount, 1)
+    let nextCount = await pager.nextPageVarMap.values.count
+    XCTAssertEqual(nextCount, 0)
   }
-
+  
   func test_loadAll() async throws {
     let pager = createPager()
-
+    
     let firstPageExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForLastItem(server: server)
     let lastPageExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForPreviousItem(server: server)
     let loadAllExpectation = expectation(description: "Load all pages")
@@ -106,7 +108,7 @@ final class ReversePaginationTests: XCTestCase, CacheDependentTesting {
     try await pager.loadAll()
     await fulfillment(of: [firstPageExpectation, lastPageExpectation, loadAllExpectation], timeout: 5)
   }
-
+  
   private func createPager() -> GraphQLQueryPager<Query, Query>.Actor {
     let initialQuery = Query()
     initialQuery.__variables = ["id": "2001", "first": 2, "before": "Y3Vyc29yMw=="]

--- a/Tests/ApolloPaginationTests/ReversePaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ReversePaginationTests.swift
@@ -1,0 +1,136 @@
+import Apollo
+import ApolloAPI
+import ApolloInternalTestHelpers
+import Combine
+import XCTest
+
+@testable import ApolloPagination
+
+final class ReversePaginationTests: XCTestCase, CacheDependentTesting {
+
+  private typealias Query = MockQuery<Mocks.Hero.ReverseFriendsQuery>
+
+  var cacheType: TestCacheProvider.Type {
+    InMemoryTestCacheProvider.self
+  }
+
+  var cache: NormalizedCache!
+  var server: MockGraphQLServer!
+  var client: ApolloClient!
+  var cancellables: [AnyCancellable] = []
+
+  override func setUpWithError() throws {
+    try super.setUpWithError()
+
+    cache = try makeNormalizedCache()
+    let store = ApolloStore(cache: cache)
+
+    server = MockGraphQLServer()
+    let networkTransport = MockNetworkTransport(server: server, store: store)
+
+    client = ApolloClient(networkTransport: networkTransport, store: store)
+    MockSchemaMetadata.stub_cacheKeyInfoForType_Object = IDCacheKeyProvider.resolver
+  }
+
+  override func tearDownWithError() throws {
+    cache = nil
+    server = nil
+    client = nil
+    cancellables.forEach { $0.cancel() }
+    cancellables = []
+
+    try super.tearDownWithError()
+  }
+
+  func test_fetchMultiplePages() async throws {
+    let pager = createPager()
+
+    let serverExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForLastItem(server: server)
+
+    var results: [Result<(Query.Data, [Query.Data], UpdateSource), Error>] = []
+    let firstPageExpectation = expectation(description: "First page")
+    var subscription = await pager.subscribe(onUpdate: { _ in
+      firstPageExpectation.fulfill()
+    })
+    await pager.fetch()
+    await fulfillment(of: [serverExpectation, firstPageExpectation], timeout: 1)
+    subscription.cancel()
+    var result = try await XCTUnwrapping(await pager.currentValue)
+    results.append(result)
+    XCTAssertSuccessResult(result) { value in
+      let (first, next, source) = value
+      XCTAssertTrue(next.isEmpty)
+      XCTAssertEqual(first.hero.friendsConnection.friends.count, 2)
+      XCTAssertEqual(first.hero.friendsConnection.totalCount, 3)
+      XCTAssertEqual(source, .fetch)
+    }
+
+    let secondPageExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForPreviousItem(server: server)
+    let secondPageFetch = expectation(description: "Second Page")
+    secondPageFetch.expectedFulfillmentCount = 2
+    subscription = await pager.subscribe(onUpdate: { _ in
+      secondPageFetch.fulfill()
+    })
+
+    try await pager.loadPrevious()
+    await fulfillment(of: [secondPageExpectation, secondPageFetch], timeout: 1)
+    subscription.cancel()
+
+    result = try await XCTUnwrapping(await pager.currentValue)
+    results.append(result)
+
+    try XCTAssertSuccessResult(result) { value in
+      let (_, next, source) = value
+      // Assert first page is unchanged
+      XCTAssertEqual(try? results.first?.get().0, try? results.last?.get().0)
+
+      XCTAssertFalse(next.isEmpty)
+      XCTAssertEqual(next.count, 1)
+      let page = try XCTUnwrap(next.first)
+      XCTAssertEqual(page.hero.friendsConnection.friends.count, 1)
+      XCTAssertEqual(source, .fetch)
+    }
+    let count = await pager.varMap.values.count
+    XCTAssertEqual(count, 1)
+  }
+
+  func test_loadAll() async throws {
+    let pager = createPager()
+
+    let firstPageExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForLastItem(server: server)
+    let lastPageExpectation = Mocks.Hero.ReverseFriendsQuery.expectationForPreviousItem(server: server)
+    let loadAllExpectation = expectation(description: "Load all pages")
+    await pager.subscribe(onUpdate: { _ in
+      loadAllExpectation.fulfill()
+    }).store(in: &cancellables)
+    try await pager.loadAll()
+    await fulfillment(of: [firstPageExpectation, lastPageExpectation, loadAllExpectation], timeout: 5)
+  }
+
+  private func createPager() -> GraphQLQueryPager<Query, Query>.Actor {
+    let initialQuery = Query()
+    initialQuery.__variables = ["id": "2001", "first": 2, "before": "Y3Vyc29yMw=="]
+    return GraphQLQueryPager<Query, Query>.Actor(
+      client: client,
+      initialQuery: initialQuery,
+      extractPageInfo: { data in
+        switch data {
+        case .initial(let data), .paginated(let data):
+          return CursorBasedPagination.ReversePagination(
+            hasPrevious: data.hero.friendsConnection.pageInfo.hasPreviousPage,
+            startCursor: data.hero.friendsConnection.pageInfo.startCursor
+          )
+        }
+      },
+      nextPageResolver: { pageInfo in
+        let nextQuery = Query()
+        nextQuery.__variables = [
+          "id": "2001",
+          "first": 2,
+          "before": pageInfo.startCursor,
+        ]
+        return nextQuery
+      }
+    )
+  }
+}

--- a/Tests/ApolloPaginationTests/ReversePaginationTests.swift
+++ b/Tests/ApolloPaginationTests/ReversePaginationTests.swift
@@ -122,7 +122,8 @@ final class ReversePaginationTests: XCTestCase, CacheDependentTesting {
           )
         }
       },
-      nextPageResolver: { pageInfo in
+      nextPageResolver: nil,
+      previousPageResolver: { pageInfo in
         let nextQuery = Query()
         nextQuery.__variables = [
           "id": "2001",

--- a/Tests/ApolloPaginationTests/SubscribeTests.swift
+++ b/Tests/ApolloPaginationTests/SubscribeTests.swift
@@ -62,12 +62,11 @@ final class SubscribeTest: XCTestCase, CacheDependentTesting {
     await fulfillment(of: [serverExpectation, initialFetchExpectation], timeout: 1.0)
     XCTAssertFalse(results.isEmpty)
     let result = try XCTUnwrap(results.first)
-    XCTAssertSuccessResult(result) { value in
-      let (first, next, source) = value
-      XCTAssertTrue(next.isEmpty)
-      XCTAssertEqual(first.hero.friendsConnection.friends.count, 2)
-      XCTAssertEqual(first.hero.friendsConnection.totalCount, 3)
-      XCTAssertEqual(source, .fetch)
+    XCTAssertSuccessResult(result) { output in
+      XCTAssertTrue(output.nextPages.isEmpty)
+      XCTAssertEqual(output.initialPage.hero.friendsConnection.friends.count, 2)
+      XCTAssertEqual(output.initialPage.hero.friendsConnection.totalCount, 3)
+      XCTAssertEqual(output.updateSource, .fetch)
       XCTAssertEqual(results.count, otherResults.count)
     }
   }

--- a/Tests/ApolloPaginationTests/SubscribeTests.swift
+++ b/Tests/ApolloPaginationTests/SubscribeTests.swift
@@ -95,7 +95,8 @@ final class SubscribeTest: XCTestCase, CacheDependentTesting {
           "after": pageInfo.endCursor,
         ]
         return nextQuery
-      }
+      },
+      previousPageResolver: nil
     )
   }
 }

--- a/apollo-ios-pagination/Sources/ApolloPagination/AnyGraphQLPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AnyGraphQLPager.swift
@@ -78,6 +78,13 @@ public class AnyGraphQLQueryPager<Model> {
     return cancellable
   }
 
+  public func loadPrevious(
+    cachePolicy: CachePolicy = .returnCacheDataAndFetch,
+    completion: (@MainActor () -> Void)? = nil
+  ) throws {
+    try pager.loadPrevious(cachePolicy: cachePolicy, completion: completion)
+  }
+
   public func loadMore(
     cachePolicy: CachePolicy = .returnCacheDataAndFetch,
     completion: (@MainActor () -> Void)? = nil

--- a/apollo-ios-pagination/Sources/ApolloPagination/AnyGraphQLPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/AnyGraphQLPager.swift
@@ -96,6 +96,10 @@ public class AnyGraphQLQueryPager<Model> {
   public func cancel() {
     pager.cancel()
   }
+
+  public func loadAll() throws {
+    try pager.loadAll()
+  }
 }
 
 extension GraphQLQueryPager.Actor {

--- a/apollo-ios-pagination/Sources/ApolloPagination/CursorBasedPagination/BidirectionalPagination.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/CursorBasedPagination/BidirectionalPagination.swift
@@ -1,0 +1,23 @@
+extension CursorBasedPagination {
+  public struct BidirectionalPagination: PaginationInfo, Hashable {
+    public let hasNext: Bool
+    public let endCursor: String?
+    public let hasPrevious: Bool
+    public let startCursor: String?
+
+    public var canLoadMore: Bool { hasNext }
+    public var canLoadPrevious: Bool { hasPrevious }
+
+    public init(
+      hasNext: Bool,
+      endCursor: String?,
+      hasPrevious: Bool,
+      startCursor: String?
+    ) {
+      self.hasNext = hasNext
+      self.endCursor = endCursor
+      self.hasPrevious = hasPrevious
+      self.startCursor = startCursor
+    }
+  }
+}

--- a/apollo-ios-pagination/Sources/ApolloPagination/CursorBasedPagination/ForwardPagination.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/CursorBasedPagination/ForwardPagination.swift
@@ -1,14 +1,14 @@
 extension CursorBasedPagination {
-    public struct ForwardPagination: PaginationInfo, Hashable {
-        public let hasNext: Bool
-        public let endCursor: String?
+  public struct ForwardPagination: PaginationInfo, Hashable {
+    public let hasNext: Bool
+    public let endCursor: String?
 
-        public var canLoadMore: Bool { hasNext }
+    public var canLoadMore: Bool { hasNext }
+    public var canLoadPrevious: Bool { false }
 
-        public init(hasNext: Bool, endCursor: String?) {
-            self.hasNext = hasNext
-            self.endCursor = endCursor
-        }
+    public init(hasNext: Bool, endCursor: String?) {
+      self.hasNext = hasNext
+      self.endCursor = endCursor
     }
-
+  }
 }

--- a/apollo-ios-pagination/Sources/ApolloPagination/CursorBasedPagination/ReversePagination.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/CursorBasedPagination/ReversePagination.swift
@@ -1,14 +1,14 @@
 extension CursorBasedPagination {
-    public struct ReversePagination: PaginationInfo, Hashable {
-        public let hasPrevious: Bool
-        public let startCursor: String?
+  public struct ReversePagination: PaginationInfo, Hashable {
+    public let hasPrevious: Bool
+    public let startCursor: String?
 
-        public var canLoadMore: Bool { hasPrevious }
+    public var canLoadMore: Bool { false }
+    public var canLoadPrevious: Bool { hasPrevious }
 
-        public init(hasPrevious: Bool, startCursor: String?) {
-            self.hasPrevious = hasPrevious
-            self.startCursor = startCursor
-        }
+    public init(hasPrevious: Bool, startCursor: String?) {
+      self.hasPrevious = hasPrevious
+      self.startCursor = startCursor
     }
-
+  }
 }

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
@@ -2,11 +2,11 @@ import Apollo
 import ApolloAPI
 
 extension GraphQLQueryPager {
-  static func makeForwardCursorQueryPager(
+  public static func makeForwardCursorQueryPager(
     client: ApolloClientProtocol,
     queryProvider: @escaping (CursorBasedPagination.ForwardPagination?) -> InitialQuery,
     extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ForwardPagination
-  ) -> GraphQLQueryPager.Actor where InitialQuery == PaginatedQuery {
+  ) -> GraphQLQueryPager where InitialQuery == PaginatedQuery {
     .init(
       client: client,
       initialQuery: queryProvider(nil),
@@ -16,13 +16,13 @@ extension GraphQLQueryPager {
     )
   }
 
-  static func makeForwardCursorQueryPager(
+  public static func makeForwardCursorQueryPager(
     client: ApolloClientProtocol,
     initialQuery: InitialQuery,
     extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ForwardPagination,
     extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.ForwardPagination,
     nextPageResolver: @escaping (CursorBasedPagination.ForwardPagination) -> PaginatedQuery
-  ) -> GraphQLQueryPager.Actor {
+  ) -> GraphQLQueryPager {
     .init(
       client: client,
       initialQuery: initialQuery,
@@ -35,11 +35,11 @@ extension GraphQLQueryPager {
     )
   }
 
-  static func makeReverseCursorQueryPager(
+  public static func makeReverseCursorQueryPager(
     client: ApolloClientProtocol,
     queryProvider: @escaping (CursorBasedPagination.ReversePagination?) -> InitialQuery,
     extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ReversePagination
-  ) -> GraphQLQueryPager.Actor where InitialQuery == PaginatedQuery {
+  ) -> GraphQLQueryPager where InitialQuery == PaginatedQuery {
     .init(
       client: client,
       initialQuery: queryProvider(nil),
@@ -49,13 +49,13 @@ extension GraphQLQueryPager {
     )
   }
 
-  static func makeReverseCursorQueryPager(
+  public static func makeReverseCursorQueryPager(
     client: ApolloClientProtocol,
     initialQuery: InitialQuery,
     extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ReversePagination,
     extractPreviousPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.ReversePagination,
     previousPageResolver: @escaping (CursorBasedPagination.ReversePagination) -> PaginatedQuery
-  ) -> GraphQLQueryPager.Actor {
+  ) -> GraphQLQueryPager {
     .init(
       client: client,
       initialQuery: initialQuery,

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
@@ -67,6 +67,42 @@ public extension GraphQLQueryPager {
       previousPageResolver: previousPageResolver
     )
   }
+
+  static func makeBidirectionalCursorQueryPager(
+    client: ApolloClientProtocol,
+    initialQuery: InitialQuery,
+    queryProvider: @escaping (CursorBasedPagination.BidirectionalPagination?) -> PaginatedQuery,
+    previousQueryProvider: @escaping (CursorBasedPagination.BidirectionalPagination?) -> PaginatedQuery,
+    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.BidirectionalPagination,
+    extractPaginatedPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.BidirectionalPagination
+  ) -> GraphQLQueryPager {
+    .init(
+      client: client,
+      initialQuery: initialQuery,
+      extractPageInfo: pageExtraction(
+        initialTransfom: extractInitialPageInfo,
+        paginatedTransform: extractPaginatedPageInfo
+      ),
+      nextPageResolver: queryProvider,
+      previousPageResolver: previousQueryProvider
+    )
+  }
+
+  static func makeBidirectionalCursorQueryPager(
+    client: ApolloClientProtocol,
+    start: CursorBasedPagination.BidirectionalPagination?,
+    queryProvider: @escaping (CursorBasedPagination.BidirectionalPagination?) -> InitialQuery,
+    previousQueryProvider: @escaping (CursorBasedPagination.BidirectionalPagination?) -> InitialQuery,
+    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.BidirectionalPagination
+  ) -> GraphQLQueryPager where InitialQuery == PaginatedQuery {
+    .init(
+      client: client,
+      initialQuery: queryProvider(start),
+      extractPageInfo: pageExtraction(transform: extractPageInfo),
+      nextPageResolver: queryProvider,
+      previousPageResolver: previousQueryProvider
+    )
+  }
 }
 
 private func pageExtraction<InitialQuery: GraphQLQuery, NextQuery: GraphQLQuery, P: PaginationInfo>(

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
@@ -1,8 +1,8 @@
 import Apollo
 import ApolloAPI
 
-extension GraphQLQueryPager {
-  public static func makeForwardCursorQueryPager(
+public extension GraphQLQueryPager {
+  static func makeForwardCursorQueryPager(
     client: ApolloClientProtocol,
     queryProvider: @escaping (CursorBasedPagination.ForwardPagination?) -> InitialQuery,
     extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ForwardPagination
@@ -16,7 +16,7 @@ extension GraphQLQueryPager {
     )
   }
 
-  public static func makeForwardCursorQueryPager(
+  static func makeForwardCursorQueryPager(
     client: ApolloClientProtocol,
     initialQuery: InitialQuery,
     extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ForwardPagination,
@@ -35,7 +35,7 @@ extension GraphQLQueryPager {
     )
   }
 
-  public static func makeReverseCursorQueryPager(
+  static func makeReverseCursorQueryPager(
     client: ApolloClientProtocol,
     queryProvider: @escaping (CursorBasedPagination.ReversePagination?) -> InitialQuery,
     extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ReversePagination
@@ -49,7 +49,7 @@ extension GraphQLQueryPager {
     )
   }
 
-  public static func makeReverseCursorQueryPager(
+  static func makeReverseCursorQueryPager(
     client: ApolloClientProtocol,
     initialQuery: InitialQuery,
     extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ReversePagination,

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
@@ -63,8 +63,8 @@ public extension GraphQLQueryPager {
         initialTransfom: extractInitialPageInfo,
         paginatedTransform: extractPreviousPageInfo
       ),
-      nextPageResolver: previousPageResolver,
-      previousPageResolver: nil
+      nextPageResolver: nil,
+      previousPageResolver: previousPageResolver
     )
   }
 }

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager+Convenience.swift
@@ -1,47 +1,18 @@
 import Apollo
 import ApolloAPI
 
-extension GraphQLQueryPager.Actor {
-  static func makeQueryPager<P: PaginationInfo>(
-    client: ApolloClientProtocol,
-    queryProvider: @escaping (P?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> P
-  ) -> GraphQLQueryPager.Actor where InitialQuery == PaginatedQuery {
-    .init(
-      client: client,
-      initialQuery: queryProvider(nil),
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      nextPageResolver: queryProvider
-    )
-  }
-
-  static func makeQueryPager<P: PaginationInfo>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> P,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> P,
-    nextPageResolver: @escaping (P) -> PaginatedQuery
-  ) -> GraphQLQueryPager.Actor {
-    .init(
-      client: client,
-      initialQuery: initialQuery,
-      extractPageInfo: pageExtraction(
-        initialTransfom: extractInitialPageInfo,
-        paginatedTransform: extractNextPageInfo
-      ),
-      nextPageResolver: nextPageResolver
-    )
-  }
-
+extension GraphQLQueryPager {
   static func makeForwardCursorQueryPager(
     client: ApolloClientProtocol,
     queryProvider: @escaping (CursorBasedPagination.ForwardPagination?) -> InitialQuery,
     extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ForwardPagination
   ) -> GraphQLQueryPager.Actor where InitialQuery == PaginatedQuery {
-    .makeQueryPager(
+    .init(
       client: client,
-      queryProvider: queryProvider,
-      extractPageInfo: extractPageInfo
+      initialQuery: queryProvider(nil),
+      extractPageInfo: pageExtraction(transform: extractPageInfo),
+      nextPageResolver: queryProvider,
+      previousPageResolver: nil
     )
   }
 
@@ -52,12 +23,15 @@ extension GraphQLQueryPager.Actor {
     extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.ForwardPagination,
     nextPageResolver: @escaping (CursorBasedPagination.ForwardPagination) -> PaginatedQuery
   ) -> GraphQLQueryPager.Actor {
-    makeQueryPager(
+    .init(
       client: client,
       initialQuery: initialQuery,
-      extractInitialPageInfo: extractInitialPageInfo,
-      extractNextPageInfo: extractNextPageInfo,
-      nextPageResolver: nextPageResolver
+      extractPageInfo: pageExtraction(
+        initialTransfom: extractInitialPageInfo,
+        paginatedTransform: extractNextPageInfo
+      ),
+      nextPageResolver: nextPageResolver,
+      previousPageResolver: nil
     )
   }
 
@@ -66,10 +40,12 @@ extension GraphQLQueryPager.Actor {
     queryProvider: @escaping (CursorBasedPagination.ReversePagination?) -> InitialQuery,
     extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ReversePagination
   ) -> GraphQLQueryPager.Actor where InitialQuery == PaginatedQuery {
-    .makeQueryPager(
+    .init(
       client: client,
-      queryProvider: queryProvider,
-      extractPageInfo: extractPageInfo
+      initialQuery: queryProvider(nil),
+      extractPageInfo: pageExtraction(transform: extractPageInfo),
+      nextPageResolver: nil,
+      previousPageResolver: queryProvider
     )
   }
 
@@ -77,104 +53,18 @@ extension GraphQLQueryPager.Actor {
     client: ApolloClientProtocol,
     initialQuery: InitialQuery,
     extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ReversePagination,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.ReversePagination,
-    nextPageResolver: @escaping (CursorBasedPagination.ReversePagination) -> PaginatedQuery
+    extractPreviousPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.ReversePagination,
+    previousPageResolver: @escaping (CursorBasedPagination.ReversePagination) -> PaginatedQuery
   ) -> GraphQLQueryPager.Actor {
-    makeQueryPager(
-      client: client,
-      initialQuery: initialQuery,
-      extractInitialPageInfo: extractInitialPageInfo,
-      extractNextPageInfo: extractNextPageInfo,
-      nextPageResolver: nextPageResolver
-    )
-  }
-}
-
-public extension GraphQLQueryPager {
-  static func makeQueryPager<P: PaginationInfo>(
-    client: ApolloClientProtocol,
-    queryProvider: @escaping (P?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> P
-  ) -> GraphQLQueryPager where InitialQuery == PaginatedQuery {
-    .init(
-      client: client,
-      initialQuery: queryProvider(nil),
-      extractPageInfo: pageExtraction(transform: extractPageInfo),
-      nextPageResolver: queryProvider
-    )
-  }
-
-  static func makeQueryPager<P: PaginationInfo>(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> P,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> P,
-    nextPageResolver: @escaping (P) -> PaginatedQuery
-  ) -> GraphQLQueryPager {
     .init(
       client: client,
       initialQuery: initialQuery,
       extractPageInfo: pageExtraction(
         initialTransfom: extractInitialPageInfo,
-        paginatedTransform: extractNextPageInfo
+        paginatedTransform: extractPreviousPageInfo
       ),
-      nextPageResolver: nextPageResolver
-    )
-  }
-
-  static func makeForwardCursorQueryPager(
-    client: ApolloClientProtocol,
-    queryProvider: @escaping (CursorBasedPagination.ForwardPagination?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ForwardPagination
-  ) -> GraphQLQueryPager where InitialQuery == PaginatedQuery {
-    .makeQueryPager(
-      client: client,
-      queryProvider: queryProvider,
-      extractPageInfo: extractPageInfo
-    )
-  }
-
-  static func makeForwardCursorQueryPager(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ForwardPagination,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.ForwardPagination,
-    nextPageResolver: @escaping (CursorBasedPagination.ForwardPagination) -> PaginatedQuery
-  ) -> GraphQLQueryPager {
-    makeQueryPager(
-      client: client,
-      initialQuery: initialQuery,
-      extractInitialPageInfo: extractInitialPageInfo,
-      extractNextPageInfo: extractNextPageInfo,
-      nextPageResolver: nextPageResolver
-    )
-  }
-
-  static func makeReverseCursorQueryPager(
-    client: ApolloClientProtocol,
-    queryProvider: @escaping (CursorBasedPagination.ReversePagination?) -> InitialQuery,
-    extractPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ReversePagination
-  ) -> GraphQLQueryPager where InitialQuery == PaginatedQuery {
-    .makeQueryPager(
-      client: client,
-      queryProvider: queryProvider,
-      extractPageInfo: extractPageInfo
-    )
-  }
-
-  static func makeReverseCursorQueryPager(
-    client: ApolloClientProtocol,
-    initialQuery: InitialQuery,
-    extractInitialPageInfo: @escaping (InitialQuery.Data) -> CursorBasedPagination.ReversePagination,
-    extractNextPageInfo: @escaping (PaginatedQuery.Data) -> CursorBasedPagination.ReversePagination,
-    nextPageResolver: @escaping (CursorBasedPagination.ReversePagination) -> PaginatedQuery
-  ) -> GraphQLQueryPager {
-    makeQueryPager(
-      client: client,
-      initialQuery: initialQuery,
-      extractInitialPageInfo: extractInitialPageInfo,
-      extractNextPageInfo: extractNextPageInfo,
-      nextPageResolver: nextPageResolver
+      nextPageResolver: previousPageResolver,
+      previousPageResolver: nil
     )
   }
 }

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -77,10 +77,10 @@ public class GraphQLQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: Graph
       previousPageVarMapPublisher.combineLatest(initialPublisher, nextPageVarMapPublisher).sink { [weak self] _ in
         guard let self else { return }
         Task {
-          let canLoadNext = await self.pager.pageTransformation()?.canLoadMore
-          let canLoadPrevious = await self.pager.previousPageTransformation()?.canLoadPrevious
-          self.canLoadNextSubject.send(canLoadNext ?? false)
-          self.canLoadPreviousSubject.send(canLoadPrevious ?? false)
+          let canLoadNext = await self.pager.canLoadNext
+          let canLoadPrevious = await self.pager.canLoadPrevious
+          self.canLoadNextSubject.send(canLoadNext)
+          self.canLoadPreviousSubject.send(canLoadPrevious)
         }
       }.store(in: &cancellables)
     }
@@ -568,14 +568,14 @@ extension GraphQLQueryPager {
       subscribers = []
     }
 
-    fileprivate func pageTransformation() -> PaginationInfo? {
+    private func pageTransformation() -> PaginationInfo? {
       guard let last = nextPageVarMap.values.last else {
         return initialPageResult.flatMap { extractPageInfo(.initial($0)) }
       }
       return extractPageInfo(.paginated(last))
     }
 
-    fileprivate func previousPageTransformation() -> PaginationInfo? {
+    private func previousPageTransformation() -> PaginationInfo? {
       guard let first = previousPageVarMap.values.last else {
         return initialPageResult.flatMap { extractPageInfo(.initial($0)) }
       }

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -238,7 +238,6 @@ extension GraphQLQueryPager {
     public func subscribe(onUpdate: @MainActor @escaping (Result<Output, Error>) -> Void) -> AnyCancellable {
       $currentValue.compactMap({ $0 }).sink { [weak self] result in
         guard let self else { return }
-        print(result)
         Task {
           let isLoadingAll = await self.isLoadingAll
           guard !isLoadingAll else { return }

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -271,6 +271,8 @@ extension GraphQLQueryPager {
       initialPageResult = nil
       activeTask?.cancel()
       activeTask = nil
+      initialFetchTask?.cancel()
+      initialFetchTask = nil
       subscribers.forEach { $0.cancel() }
       subscribers.removeAll()
     }

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -458,6 +458,7 @@ extension GraphQLQueryPager {
           publisher.send(completion: .finished)
         }
       case .failure(let error):
+        publisher.send(completion: .finished)
         currentValue = .failure(error)
       }
     }
@@ -533,9 +534,6 @@ extension GraphQLQueryPager {
 
         if let latest {
           let (previousPages, firstPage, nextPage) = latest
-          if let canLoadPrevious = previousPageInfo?.canLoadPrevious, !canLoadPrevious {
-            isLoadingAll = false
-          }
           let value: Result<Output, Error> = .success(
             Output(
               previousPages: previousPages,

--- a/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/GraphQLQueryPager.swift
@@ -32,7 +32,7 @@ public class GraphQLQueryPager<InitialQuery: GraphQLQuery, PaginatedQuery: Graph
     public let nextPages: [PaginatedQuery.Data]
     public let updateSource: UpdateSource
 
-    init(
+    public init(
       previousPages: [PaginatedQuery.Data],
       initialPage: InitialQuery.Data,
       nextPages: [PaginatedQuery.Data],

--- a/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/OffsetPagination.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/OffsetBasedPagination/OffsetPagination.swift
@@ -1,6 +1,7 @@
 public struct OffsetPagination: PaginationInfo, Hashable {
   public let offset: Int
   public let canLoadMore: Bool
+  public var canLoadPrevious: Bool { false }
 
   public init(offset: Int, canLoadMore: Bool) {
     self.offset = offset

--- a/apollo-ios-pagination/Sources/ApolloPagination/PaginationInfo.swift
+++ b/apollo-ios-pagination/Sources/ApolloPagination/PaginationInfo.swift
@@ -1,3 +1,4 @@
 public protocol PaginationInfo: Sendable {
   var canLoadMore: Bool { get }
+  var canLoadPrevious: Bool { get }
 }


### PR DESCRIPTION
Note: Identical to https://github.com/apollographql/apollo-ios-dev/pull/115 -- hoping this shifts bases to point at apollographql:main once https://github.com/apollographql/apollo-ios-dev/pull/80 is merged.

### What are you trying to accomplish?

1. I want consumers of the `GraphQLPager` to be able to load all pages at once, should they desire to do so. 
2. In a quest to deliver bidirectional pagination, we must first solidify support for reverse pagination. 

closes https://github.com/apollographql/apollo-ios/issues/3265

### What approach did you choose and why?

**LoadAll Support**: 
First, I modified the `fetch` function to follow `async`/`await` syntax. That's so that we can `await` its return prior to beginning to loop over `loadMore`. 

Then, I implemented the function using a while loop.

Finally, I made additive changes to the `MockGraphQLServer` to support subsequent loads of this nature. 

**Reverse Pagination**:
Leaning hard into differentiating reverse and forward pagination from one another. 
If we are to support _both_ types of pagination at once, then they must be treated as being separate from one another: A page can be a previous page _or_ it can be a next page. It cannot be both. 

**BIdirectional Pagination**
Once reverse pagination was solidifed, this was a breeze to implement. It basically amounted to defining the pagination struct. 

<!-- Describe your thought process in making these changes. List any tradeoffs you made to take on or pay down tech debt. Identify any work you did to mitigate risk. Describe any alternative approaches you considered and why you discarded them. -->

### Anything you want to highlight for special attention from reviewers?

Note that the output for the pagination controller is now a struct. This allows us to make changes to the output without breaking previous versions.

<!-- Identify remaining risks and confess any uncertainties you may have about the correctness of the changes. Highlight anything on which you would like a second (or third) opinion. -->

### If something goes wrong, what are the mitigation strategies?

- **Rollback** - This change can only be disabled by reverting this pull request or commit.

______

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 12d13bc</samp>

### Summary
🧪🔄🔒

<!--
1.  🧪 - This emoji represents testing, experimentation, or science, and can be used to indicate the addition of new test cases or the improvement of existing ones.
2.  🔄 - This emoji represents repetition, looping, or cycling, and can be used to indicate the addition of a new feature that allows loading all the pages of a paginated query in one call, or the use of the async/await syntax to simplify the code.
3.  🔒 - This emoji represents security, privacy, or protection, and can be used to indicate the removal of an unnecessary public modifier from an internal extension, or the use of specific query instances with variables to avoid conflicts.
-->
This pull request adds a new feature to the `GraphQLQueryPager` protocol and class, which allows loading all the pages of a paginated GraphQL query in one call. It also updates the tests and the mock GraphQL server to use the new feature and the async/await syntax. Additionally, it removes some unnecessary public modifiers from internal extensions.

> _Sing, O Muse, of the swift and skillful coder_
> _Who added to the `GraphQLQueryPager` a wondrous feature_
> _To load all pages of a query with one call, like a mighty river_
> _That flows from the mountains to the sea, unstoppable and eager._

### Walkthrough
*  Add `loadAll` methods to `AnyGraphQLPager` and `GraphQLQueryPager` protocols and classes to allow loading all pages of a paginated query in one call
*  Refactor `GraphQLQueryPager.Actor` class to use async/await syntax, `initialFetchTask` property, and `isLoadingAll` flag for pagination logic and cancellation handling
*  Add test cases for `AnyGraphQLQueryPager` and `ForwardPaginationTests` using mock GraphQL server and expectations
*  Add subscript operator to `MockGraphQLServer` class to access and set `RequestExpectation` objects for different operation types
*  Modify `FriendsQuery` extension methods to use specific query instances with expected variables instead of generic operation type
*  Remove unnecessary `public` modifiers from `GraphQLQueryPager.Actor` extensions in `AnyGraphQLPager.swift` and `Pager+Convenience.swift` files
*  Move deinitializer after initializer and remove `public` modifier from initializer in `GraphQLQueryPager` class
*  Add missing import statement to `FriendsQuery+TestHelpers.swift` file 


____

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at a526e5f</samp>

### Summary
🔙🔄🧪

<!--
1.  🔙 This emoji represents the reverse pagination feature, which allows loading the previous page of a cursor-based pagination query.
2.  🔄 This emoji represents the refactoring and simplification of the code, which makes it more readable and maintainable.
3.  🧪 This emoji represents the addition and improvement of the tests, which verify the functionality and behavior of the pagination classes.
-->
This pull request adds support for reverse cursor-based pagination to the `GraphQLQueryPager` class and its related types and tests. It also refactors and simplifies some of the existing code for forward cursor-based pagination and improves the readability and maintainability of the code.

> _Oh we are the coders of the `GraphQLQueryPager`_
> _We can load the pages forward and reverse_
> _We pull the ropes and we test the code_
> _With the `PaginationInfo` protocol in force_

### Walkthrough
*  Add support for reverse pagination to the `GraphQLQueryPager` class and its related types, using a new parameter `previousPageResolver` and new properties and methods `canLoadPrevious` and `loadPrevious`
*  Update the output structure of the `GraphQLQueryPager` class to use a new struct with properties `previousPages`, `initialPage`, `nextPages`, and `updateSource`
*  Update the tests for the `GraphQLQueryPager` class and its related types to use the new output structure and the new reverse pagination functionality, adding new parameters, properties, methods, assertions, and mock types as needed 
*  Remove some print statements and empty lines from the code that are not needed